### PR TITLE
added 10-D/A parser

### DIFF
--- a/datamule/datamule.egg-info/PKG-INFO
+++ b/datamule/datamule.egg-info/PKG-INFO
@@ -5,11 +5,32 @@ Summary: Making it easier to use SEC filings.
 Home-page: https://github.com/john-friedman/datamule-python
 Author: John Friedman
 Description-Content-Type: text/markdown
-Provides-Extra: filing_viewer
+Requires-Dist: aiohttp
+Requires-Dist: aiolimiter
+Requires-Dist: tqdm
+Requires-Dist: requests
+Requires-Dist: nest_asyncio
+Requires-Dist: aiofiles
+Requires-Dist: polars
+Requires-Dist: setuptools
+Requires-Dist: selectolax
+Provides-Extra: filing-viewer
+Requires-Dist: lxml; extra == "filing-viewer"
 Provides-Extra: mulebot
-Provides-Extra: mulebot_server
-Provides-Extra: dataset_builder
+Requires-Dist: openai; extra == "mulebot"
+Provides-Extra: mulebot-server
+Requires-Dist: flask; extra == "mulebot-server"
+Provides-Extra: dataset-builder
+Requires-Dist: pandas; extra == "dataset-builder"
+Requires-Dist: google-generativeai; extra == "dataset-builder"
+Requires-Dist: psutil; extra == "dataset-builder"
 Provides-Extra: all
+Requires-Dist: flask; extra == "all"
+Requires-Dist: pandas; extra == "all"
+Requires-Dist: lxml; extra == "all"
+Requires-Dist: openai; extra == "all"
+Requires-Dist: psutil; extra == "all"
+Requires-Dist: google-generativeai; extra == "all"
 
 # datamule
 

--- a/datamule/datamule.egg-info/SOURCES.txt
+++ b/datamule/datamule.egg-info/SOURCES.txt
@@ -44,6 +44,7 @@ datamule/mulebot/mulebot_server/static/scripts/tableArtifacts.js
 datamule/mulebot/mulebot_server/static/scripts/utils.js
 datamule/mulebot/mulebot_server/templates/chat-minimalist.html
 datamule/parser/__init__.py
+datamule/parser/basic_10da_parser.py
 datamule/parser/basic_10k_parser.py
 datamule/parser/basic_10q_parser.py
 datamule/parser/basic_13d_parser.py

--- a/datamule/datamule.egg-info/requires.txt
+++ b/datamule/datamule.egg-info/requires.txt
@@ -10,10 +10,10 @@ selectolax
 
 [all]
 flask
-psutil
 pandas
 lxml
 openai
+psutil
 google-generativeai
 
 [dataset_builder]

--- a/datamule/datamule/parser/basic_10da_parser.py
+++ b/datamule/datamule/parser/basic_10da_parser.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+import re
+from .helper import load_file_content, clean_title
+
+PART_PATTERN = re.compile(r'\n\s*part[.:)?\s]+([IVX]+|\d+)', re.I)
+ITEM_PATTERN = re.compile(r'\n\s*item[.:)?\s]+(\d+[A-Z]?)', re.I)
+#IS_10K_PATTERN = re.compile(r'item[.:)?\s]+14', re.I)
+TOC_END_PATTERN = re.compile(r'(?:item[.:)?\s]+14).*?(?=\n\s*item[.:)?\s]+1\b)', re.I | re.DOTALL)
+
+ROMAN_TO_NUM = {'I': '1', 'II': '2', 'III': '3', 'IV': '4'}
+
+ITEM_TO_PART = {
+   '1': 'I', '1A': 'I', '1B': 'I', '1C': 'I', '2': 'I', '3': 'I', '4': 'I',
+   '5': 'II', '6': 'II', '7': 'II', '7A': 'II', '8': 'II', '9': 'II', '9A': 'II', '9B': 'II', '9C': 'II',
+   '10': 'III', '11': 'III', '12': 'III', '13': 'III', '14': 'III',
+   '15': 'IV', '16': 'IV', '16A': 'IV'
+}
+
+def find_content_start(content):
+   toc_match = TOC_END_PATTERN.search(content)
+   if toc_match:
+       item_1_pattern = re.compile(r'\n\s*item\s*1\b', re.I)
+       item_1_match = item_1_pattern.search(content, toc_match.end())
+       if item_1_match:
+           return item_1_match.start()
+   return 0
+
+def find_anchors(content):
+   start_pos = find_content_start(content)
+   content = '\n' + content[start_pos:]
+   
+   anchors = []
+   for part_match in PART_PATTERN.finditer(content):
+       anchors.append(('part', part_match.group(1), part_match.start() + start_pos, part_match.group()))
+       
+   for item_match in ITEM_PATTERN.finditer(content):
+       anchors.append(('item', item_match.group(1), item_match.start() + start_pos, item_match.group()))
+   
+   return sorted(anchors, key=lambda x: x[2])
+
+def extract_sections(content, anchors, filename):
+    if not anchors:
+        return {}
+        
+    result = {
+        "metadata": {"document_name": Path(filename).stem},
+        "document": {
+            "part1": {}, "part2": {}, "part3": {}, "part4": {}
+        }
+    }
+    
+    last_item = None
+    current_text = None
+    
+    for i, current in enumerate(anchors):
+        if current[0] == 'item':
+            next_pos = anchors[i+1][2] if i < len(anchors)-1 else len(content)
+            text = content[current[2]:next_pos].strip()
+            
+            if current[1] == last_item:
+                current_text += "\n\n" + text
+            else:
+                if last_item and last_item in ITEM_TO_PART:
+                    part_num = ROMAN_TO_NUM[ITEM_TO_PART[last_item]]
+                    result["document"][f"part{part_num}"][f"item{last_item.lower()}"] = current_text
+                current_text = text
+                last_item = current[1]
+    
+    if last_item and last_item in ITEM_TO_PART:
+        part_num = ROMAN_TO_NUM[ITEM_TO_PART[last_item]]
+        result["document"][f"part{part_num}"][f"item{last_item.lower()}"] = current_text
+    
+    # Only keep non-empty parts
+    result["document"] = {k:v for k,v in result["document"].items() if v}
+    return result
+
+def parse_10da(filename):
+   content = load_file_content(filename)
+   anchors = find_anchors(content)
+   return extract_sections(content, anchors, filename)

--- a/datamule/datamule/parser/helper.py
+++ b/datamule/datamule/parser/helper.py
@@ -18,7 +18,7 @@ def load_html_content(filename):
     for node in hidden_nodes:
         node.decompose()
     
-    blocks = {'p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'article', 'section', 'li', 'td'}
+    blocks = {'p', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'article', 'section', 'li', 'td','a'}
     lines = []
     current_line = []
     

--- a/datamule/datamule/parser/sec_parser.py
+++ b/datamule/datamule/parser/sec_parser.py
@@ -9,6 +9,7 @@ from .form_d_parser import parse_form_d
 from .n_port_p_parser import parse_nport_p
 from .basic_13d_parser import parse_13d
 from .basic_13g_parser import parse_13g
+from .basic_10da_parser import parse_10da
 
 class Parser:
 
@@ -36,6 +37,8 @@ class Parser:
             return parse_13d(filename)
         elif filing_type == 'SC 13G':
             return parse_13g(filename)
+        elif filing_type == '10-D/A':
+            return parse_10da(filename)
         else:
             data = parse_textual_filing(url=filename, return_type='json')
         return data 

--- a/datamule/datamule/sec_filing.py
+++ b/datamule/datamule/sec_filing.py
@@ -124,3 +124,5 @@ class Filing:
             return iter(self._document_to_section_text(self.data['document']))
         elif self.filing_type == 'SC 13G':
             return iter(self._document_to_section_text(self.data['document']))
+        elif self.filing_type == '10-D/A':
+            return iter(self._document_to_section_text(self.data['document']))


### PR DESCRIPTION
Hi @john-friedman ,

This contribution is wrt to this issue - https://github.com/john-friedman/datamule-python/issues/7

Currently I am able to parse the 10-D/A filing. However, It doesnt parse the exhibit file linked in the **'Item 10- Exhibits'** section.

Can we discuss how to go about that.

Meanwhile, here is an example of parsing a 10-D/A document - https://www.sec.gov/Archives/edgar/data/1571237/000188852421003644/msb13c09_10da-202110.htm

Parsed output:

```
{
   "metadata":{
      "document_name":"msb13c09_10da-202110.htm - Generated by SEC Publisher for SEC Filing"
   },
   "document":{
      "part1":{
         "item1":"Item 1. Distribution and Pool Performance Information.\n\nOn October 18, 2021 a distribution was\nmade to holders of the certificates issued by Morgan\nStanley Bank of America Merrill Lynch Trust 2013-C9.\n\nThe distribution report is attached as an Exhibit to this Form 10-D/A,\nplease see Item 10(b), Exhibit 99.1 for the related information.\n\nThe following table presents the loss information for the trust assets for\nthe Morgan Stanley Bank of America Merrill Lynch Trust\n2013-C9 in accordance with Item 1100(b) as required by Item\n1121(a)(9) of Regulation AB:\n\nLoss Information as reported on October 18, 2021\n\nNumber of Delinquencies 30+ days\n\n% of Delinquencies 30+ days by Pool\n  Balance\n\nNumber of Loans/REOs with Losses\n\nAverage Net Loss\n\n2\n\n18.21%\n\n0\n\nN/A\n\nNo\nassets securitized by Morgan Stanley Mortgage Capital\nHoldings LLC and Bank of America, National Association (each a\n\"Securitizer\") and held by Morgan Stanley Bank\nof America Merrill Lynch Trust 2013-C9 were the subject of a demand\nto repurchase or replace for breach of the representations and warranties\nduring the monthly distribution period from September 18,\n2021 to October 18, 2021.\n\nMorgan Stanley Mortgage Capital\nHoldings LLC filed its most recent Form ABS-15G on August 16, 2021. The CIK number for Morgan Stanley Mortgage Capital Holdings LLC is 0001541557.\n\nBank of America, National\nAssociation filed its most recent Form ABS-15G on August 11, 2021. The CIK number for Bank of America, National Association is 0001102113."
      },
      "part2":{
         "item6":"Item 6. Significant Obligors of Pool Assets.\n\nThe Milford Plaza\nFee mortgage loan constitutes a significant obligor within the meaning of Item\n1101(k)(2) of Regulation AB and as disclosed in the Prospectus Supplement for\nMorgan Stanley Bank of America Merrill Lynch Trust 2013-C9. In accordance with"
      },
      "part3":{
         "item10":"Item 10. Exhibits.\n\n(a) The following is a list of documents filed as part of this Report on\nForm 10-D/A:\n\n(99.1)\n\nAmended monthly report\ndistributed to holders of the certificates issued by Morgan\nStanley Bank of America Merrill Lynch Trust 2013-C9, relating to the October 18, 2021 distribution.\n\n(b) The exhibits required to be filed by the Registrant pursuant to this\nForm are listed above.\n\nSIGNATURES\n\nPursuant to the requirements of the Securities Exchange Act of 1934, the\nregistrant has duly caused this report to be signed on its behalf by the\nundersigned thereunto duly authorized.\n\nMorgan Stanley Capital I Inc. (Depositor)\n\n/s/ Jane Lam Jane Lam, President\n\nDate: December 23, 2021"
      }
   }
}
```
Thanks!