### PR TITLE
Bugfix/packageupdater import error

### DIFF
--- a/datamule/datamule/downloader/__init__.py
+++ b/datamule/datamule/downloader/__init__.py
@@ -1,2 +1,0 @@
-from .downloader import PreciseRateLimiter
-from .downloader import RateMonitor

--- a/datamule/datamule/downloader/__init__.py
+++ b/datamule/datamule/downloader/__init__.py
@@ -1,0 +1,2 @@
+from .downloader import PreciseRateLimiter
+from .downloader import RateMonitor

--- a/datamule/datamule/packageupdater.py
+++ b/datamule/datamule/packageupdater.py
@@ -5,7 +5,7 @@ import csv
 import os
 from pkg_resources import resource_filename
 from .helper import headers
-from .downloader import PreciseRateLimiter, RateMonitor
+from .downloader.downloader import PreciseRateLimiter, RateMonitor
 
 class PackageUpdater:
     def __init__(self):


### PR DESCRIPTION
When attempting to import PackageUpdater the PreciseRateLimiter class was unable to be found. This was caused by the downloader path being a package rather than a file. This can be fixed by specifying in the import statement to import from the location `.downloader.downloader`

Example traceback:
❯ python3 scratch.py
Traceback (most recent call last):
  File "/datamule-python/scratch.py", line 2, in <module>
    from datamule import PackageUpdater
  File "/datamule-python/.venv/lib/python3.10/site-packages/datamule/__init__.py", line 19, in __getattr__
    from .packageupdater import PackageUpdater
  File "/datamule-python/.venv/lib/python3.10/site-packages/datamule/packageupdater.py", line 8, in <module>
    from .downloader import PreciseRateLimiter, RateMonitor
ImportError: cannot import name 'PreciseRateLimiter' from 'datamule.downloader' (unknown location)