### PR TITLE
Keep original handlers if already set

### DIFF
--- a/datamule/datamule/datamule/downloader.py
+++ b/datamule/datamule/datamule/downloader.py
@@ -23,7 +23,11 @@ from ..utils.format_accession import format_accession
 # could be cleaned up
 
 # Set up logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=logging.getLogger().handlers,
+)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
A user of the library may already set their own logging handlers for centralized logging, if we directly use basicConfig here, it will override all previously set handlers.