### PR TITLE
Fix skip_accession_numbers in SEC streamer; fix submissions_loaded flag in Portfolio

### DIFF
--- a/datamule/datamule/portfolio/portfolio.py
+++ b/datamule/datamule/portfolio/portfolio.py
@@ -34,7 +34,6 @@ class Portfolio:
         
         if self.path.exists():
             self._load_submissions()
-            self.submissions_loaded = True
         else:
             self.path.mkdir(parents=True, exist_ok=True)
 
@@ -80,6 +79,8 @@ class Portfolio:
         # Combine and filter None values  
         self.submissions = [s for s in (regular_submissions + batch_submissions) if s is not None]
         print(f"Successfully loaded {len(self.submissions)} submissions")
+
+        self.submissions_loaded = True
 
     def _load_batch_submissions_worker(self, batch_tar_path, pbar):
         """Worker function to load submissions from one batch tar with progress updates"""

--- a/datamule/datamule/sec/submissions/streamer.py
+++ b/datamule/datamule/sec/submissions/streamer.py
@@ -82,7 +82,7 @@ class Streamer(EFTSQuery):
             if self.accession_numbers is not None and accno_w_dash not in self.accession_numbers:
                 return None, None, None
             
-            if self.skip_accession_numbers is not None and accno_w_dash in self.skip_accession_numbers:
+            if self.skip_accession_numbers is not None and accno_no_dash in self.skip_accession_numbers:
                 return None, None, None
             
             # Construct the URL


### PR DESCRIPTION
Two fixes:
- Currently when using the SEC streamer, files already downloaded locally are ignored. The `skip_accession_numbers` check needs to be based on `accno_no_dash` instead of `accno_w_dash`.
- Set the `Portfolio` flag `submissions_loaded=True` within `_load_submissions()` at the end of the function, as this function can be called from a number of places within the class. Currently the flag is set only after one such calls.