### PR TITLE
Add URL from RSS entry to polling results

### DIFF
--- a/datamule/datamule/sec/submissions/monitor.py
+++ b/datamule/datamule/sec/submissions/monitor.py
@@ -32,8 +32,9 @@ async def poll_rss(limiter, session):
         cik = re.search(r'/data/(\d+)/', url).group(1)
         
         if accession not in grouped:
-            grouped[accession] = {'submission_type': '', 'ciks': set(), 'filing_date': ''}
+            grouped[accession] = {'submission_type': '', 'ciks': set(), 'filing_date': '', 'url': ''}
         
+        grouped[accession]['url'] = url
         grouped[accession]['ciks'].add(cik)
         grouped[accession]['submission_type'] = entry.find('atom:category', namespace).get('term')
         summary_text = entry.find('atom:summary', namespace).text
@@ -41,7 +42,7 @@ async def poll_rss(limiter, session):
         if filing_date_match:
             grouped[accession]['filing_date'] = filing_date_match.group(1)
 
-    results = [{'accession': int(k.replace('-', '')), 'submission_type': v['submission_type'], 'ciks': list(v['ciks']), 'filing_date': v['filing_date']} for k, v in grouped.items()]
+    results = [{'accession': int(k.replace('-', '')), 'submission_type': v['submission_type'], 'ciks': list(v['ciks']), 'filing_date': v['filing_date'], 'url': v['url']} for k, v in grouped.items()]
     return results
 
 def clean_efts_hits(hits):


### PR DESCRIPTION
### Feature Request to add the RSS feed's URL to the polling results.

After detecting events from the RSS feed a logical next step is to process the filing data, accessible via the filing's index. Generally, we can construct this URL exclusively with the accession number because it contains the filer's CIK, however there are a handful of not-so-uncommon cases where the filer's CIK does not match a reporter or issuer CIK (specifically dealing with Form 4s). 

I propose to add the URL from the RSS feed to the polling data so an index lookup with accession number is never required. My provided solution adds the URL field (which is already extracted from the RSS feed's entry) to the dictionary returned by the polling function.

Happy to engage in any further discussion about the feature.

### Extra background on why the direct Accession Number to CIK to URL does not work

In the SEC’s EDGAR system, every accepted submission is assigned a unique accession number of the form AAAAAAAAAA-YY-BBBBBB where AAAAAAAAAA is a 10-digit number (zero-padded) representing the CIK (Central Index Key) of the entity that submitted the filing.

Importantly, the first part of the accession number is the CIK of the submitting entity. This “filer” could be the company/issuer itself, the individual filer, or a third-party filing agent authorized to file on their behalf. The SEC explicitly notes that 

> “the first set of numbers … is the CIK of the entity submitting the filing. This could be the company or a third-party filer agent”. 

In other words, the accession’s CIK does not always equal the issuer’s or reporting person’s CIK - it equals whoever actually logged in to EDGAR to submit the form.

For most filings (including many Form 4 submissions), companies often file on behalf of insiders using the company’s EDGAR credentials. In those cases, the accession number’s first 10 digits will match the issuer’s CIK (since the company is the one submitting). In some cases, an insider might file their own Form 4, in which case the accession’s CIK would be the reporting owner’s CIK.

However, there are notable occurrences, especially with Form 4 (insider ownership filings), where the accession number’s CIK is neither the issuer’s nor the insider’s. This is because a third-party filing agent (such as a financial printer, law firm, or EDGAR filing service) submitted the form on behalf of the insider.

In summary, for Form 4 filings, the archive path uses the issuer’s CIK folder, not necessarily the CIK from the accession number when a third-party or issuer filed the form. The accession’s first part might be an agent, but the files sit under the issuer’s CIK directory in EDGAR.