### PR TITLE
feat(portfolio): add Portfolio.missing attribute surfacing errors.json (#78)

### DIFF
--- a/datamule/datamule/portfolio/portfolio.py
+++ b/datamule/datamule/portfolio/portfolio.py
@@ -5,6 +5,7 @@ from ..submission.submission import Submission
 from ..sec.submissions.downloader import download as sec_download
 from ..sec.submissions.textsearch import filter_text
 from ..config import Config
+import json
 import os
 import tarfile
 from threading import Lock
@@ -283,7 +284,31 @@ class Portfolio:
             )
 
         self.submissions_loaded = False
-        
+
+    @property
+    def missing(self):
+        """
+        Submissions logged as failed by the most recent download_submissions() run.
+
+        Returns a dict keyed by the filename or accession identifier that the
+        underlying downloader logged, with the captured error message as the
+        value. Reads from ``errors.json`` in ``self.path`` (the same file the
+        ``datamule-tar`` and ``datamule-sgml`` providers already write to when
+        an individual download fails).
+
+        Returns an empty dict if no errors file exists or if it cannot be
+        parsed. The direct SEC provider does not currently write to
+        errors.json, so failures from that provider will not appear here.
+        """
+        errors_path = self.path / 'errors.json'
+        if not errors_path.exists():
+            return {}
+        try:
+            with open(errors_path, 'r') as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return {}
+
     def monitor_submissions(self, data_callback=None, interval_callback=None,
                             polling_interval=1000, quiet=True, start_date=None,
                             validation_interval=600000):


### PR DESCRIPTION
## Summary

Closes #78 — adds the `Portfolio.missing` attribute described in the issue ("see what submissions may have failed to download").

Two of the three download providers (`datamule-tar` via `tar_downloader._log_error`, `datamule-sgml` via `datamule/downloader.py`) already write per-file failure information to `errors.json` in the portfolio's output directory when an individual download fails. Until now there was no public Portfolio attribute that surfaced that data — callers had to know the path on disk and parse it themselves.

`Portfolio.missing` is a read-only property that reads `errors.json` from `self.path` and returns its contents as a dict keyed by the identifier the underlying downloader logged (typically the accession-prefixed filename, e.g. `0000320193-23-000106.tar`) with the captured error message as the value. Returns an empty dict when no errors file exists or when it cannot be parsed.

## Usage

```python
portfolio.download_submissions(...)
if portfolio.missing:
    for name, err in portfolio.missing.items():
        print(f"{name}: {err}")
```

## Why read-only / why a property

The implementation is read-only and additive: no downloader is modified, no existing behaviour changes. Doing it as a `@property` rather than caching at download time keeps the source of truth in `errors.json` (which other providers may write to between Python sessions) and avoids stale state if the same Portfolio object is reused across multiple `download_submissions()` calls.

## Smoke tests (no test suite in the repo)

Verified locally that `Portfolio.missing`:

- returns `{}` on a fresh portfolio with no `errors.json`
- returns the parsed contents when `errors.json` is present
- returns `{}` on malformed JSON without raising
- matches the cumulative-append shape written by `tar_downloader._log_error`

## Out of scope (logical follow-ups)

The issue body also mentions "update errors.json for better error tracking." Two adjacent improvements worth considering as separate PRs:

1. **The direct SEC provider** (`sec_download` in `sec/submissions/downloader.py`) does not currently write to `errors.json`, so failures from that provider will not appear in `Portfolio.missing`. Extending it to use the same contract would make `missing` complete across all three providers.
2. **Richer error-tracking fields** (timestamps, retry counts, HTTP status). The current value is a flat `str(error_msg)` matching what both existing providers write. Any schema change would need agreement across providers.

Happy to follow up on either if useful.

## Files

- `datamule/datamule/portfolio/portfolio.py` (+26 / -1)